### PR TITLE
Fix for OnChatMsgSystem

### DIFF
--- a/DataStore_Crafts/DataStore_Crafts_Retail.lua
+++ b/DataStore_Crafts/DataStore_Crafts_Retail.lua
@@ -620,6 +620,11 @@ local unlearnMsg = gsub(ERR_SPELL_UNLEARNED_S, arg1pattern, "(.+)")
 local function OnChatMsgSystem(self, message)
 	if not message then return end
 
+	-- Chat lockdown by Blizzard breaks this. Not like we need to check for skills being dropped while locked, right?
+	if canaccessvalue and not canaccessvalue(message) then
+		return
+	end
+
 	-- Check it is the right type of message
 	local skillLink = message:match(unlearnMsg)
 	if not skillLink then return end


### PR DESCRIPTION
Bail if the message can't be accessed because it is 'secret'